### PR TITLE
Add `rustup` to the Rust devShell

### DIFF
--- a/devShells/default.nix
+++ b/devShells/default.nix
@@ -88,7 +88,10 @@ in
           pkgs.rustPackages.clippy
           pkgs.rustc
           pkgs.rustfmt
-          pkgs.rustup
+          (pkgs.rustup.overrideAttrs (old: {
+            ## NB: Fails on i686-linux with Nixpkgs 24.11.
+            doCheck = pkgs.system != "i686-linux";
+          }))
         ]);
   }
   // (

--- a/devShells/default.nix
+++ b/devShells/default.nix
@@ -88,6 +88,7 @@ in
           pkgs.rustPackages.clippy
           pkgs.rustc
           pkgs.rustfmt
+          pkgs.rustup
         ]);
   }
   // (


### PR DESCRIPTION
Many rust projects require a newer rustc than is included in Nixpkgs. This keeps the Nixpkgs versioning by default, but allows us to use `rustup` to sync with the rust-toolchain file, etc.