### PR TITLE
Move most project config upstream

### DIFF
--- a/.cache/vale/Vocab/flaky-environments/accept.txt
+++ b/.cache/vale/Vocab/flaky-environments/accept.txt
@@ -1,3 +1,4 @@
+Hacktoberfest
 direnv
 formatter
 garnix

--- a/.cache/vale/config/vocabularies/flaky-environments/accept.txt
+++ b/.cache/vale/config/vocabularies/flaky-environments/accept.txt
@@ -1,3 +1,4 @@
+Hacktoberfest
 direnv
 formatter
 garnix

--- a/.config/project/default.nix
+++ b/.config/project/default.nix
@@ -1,10 +1,11 @@
+### All available options for this file are listed in
+### https://sellout.github.io/project-manager/options.xhtml
 {
   config,
   flaky,
   lib,
   pkgs,
   self,
-  supportedSystems,
   ...
 }: {
   project = {
@@ -18,28 +19,12 @@
       (builtins.attrNames self.templates));
   };
 
-  ## dependency management
-  services.renovate.enable = true;
-
-  ## development
-  programs = {
-    direnv.enable = true;
-    git = {
-      # TODO: This should default by whether there is a .git file/dir (and
-      #       whether it’s a file (worktree) or dir determines other things –
-      #       like where hooks are installed.
-      enable = true;
-      ignoreRevs = [
-        "dc0697c51a4ed5479d3ac7fcb304478729ab2793" # nix fmt
-      ];
-    };
-  };
-
   ## formatting
-  editorconfig.enable = true;
   programs = {
+    git.ignoreRevs = [
+      "dc0697c51a4ed5479d3ac7fcb304478729ab2793" # nix fmt
+    ];
     treefmt = {
-      enable = true;
       ## NB: This is normally "flake.nix", but since this repo contains
       ##     sub-flakes, we pick a random file that is unlikely to exist
       ##     anywhere else in the tree (and we can’t use .git/config, because it
@@ -58,7 +43,6 @@
       };
     };
     vale = {
-      enable = true;
       ## This is a personal repository.
       formatSettings."*"."Microsoft.FirstPerson" = "NO";
       vocab.${config.project.name}.accept = [
@@ -82,12 +66,7 @@
     };
   };
 
-  ## CI
-  services.garnix.enable = true;
-
   ## publishing
-  services.flakehub.enable = true;
-  services.github.enable = true;
   services.github.settings.repository.topics = [
     "development"
     "nix-flakes"

--- a/flake.lock
+++ b/flake.lock
@@ -87,11 +87,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1762936732,
-        "narHash": "sha256-zFHmzehuJcUZXHsap7QudpOmsbZtHc0PbG4iE2wRRJI=",
+        "lastModified": 1763489760,
+        "narHash": "sha256-mzX75bBWtJMvc0ud6gdrTyzLQctNmgY50xGfEzkrhvo=",
         "owner": "sellout",
         "repo": "flaky",
-        "rev": "942fc14d2d24f37ee9faab202133fb26fa17a170",
+        "rev": "f4392bea5df71c1b3190791519110d3d19638f5c",
         "type": "github"
       },
       "original": {
@@ -139,11 +139,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762817552,
-        "narHash": "sha256-psSXHHFo+jTWKJLfU8FqpAdpr8Zcc54Ej6+nT2aMosQ=",
+        "lastModified": 1763334038,
+        "narHash": "sha256-LBVOyaH6NFzQ3X/c6vfMZ9k4SV2ofhpxeL9YnhHNJQQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "10f45407c571d137b144cc56e508d5291499e5aa",
+        "rev": "4c8cdd5b1a630e8f72c9dd9bf582b1afb3127d2c",
         "type": "github"
       },
       "original": {

--- a/templates/bash/.config/project/default.nix
+++ b/templates/bash/.config/project/default.nix
@@ -1,34 +1,11 @@
-{config, ...}: {
+### All available options for this file are listed in
+### https://sellout.github.io/project-manager/options.xhtml
+{...}: {
   project = {
     name = "{{project.name}}";
     summary = "{{project.summary}}";
   };
 
-  ## dependency management
-  services.renovate.enable = true;
-
-  ## development
-  programs = {
-    direnv.enable = true;
-    # This should default by whether there is a .git file/dir (and whether it’s
-    # a file (worktree) or dir determines other things – like where hooks
-    # are installed.
-    git.enable = true;
-  };
-
-  ## formatting
-  editorconfig.enable = true;
-  programs = {
-    treefmt.enable = true;
-    vale.enable = true;
-  };
-
-  ## CI
-  services.garnix.enable = true;
-
   ## publishing
-  services = {
-    flakehub.enable = true;
-    github.enable = true;
-  };
+  services.github.settings.repository.topics = [];
 }

--- a/templates/c/.config/project/default.nix
+++ b/templates/c/.config/project/default.nix
@@ -1,34 +1,11 @@
-{config, ...}: {
+### All available options for this file are listed in
+### https://sellout.github.io/project-manager/options.xhtml
+{...}: {
   project = {
     name = "{{project.name}}";
     summary = "{{project.summary}}";
   };
 
-  ## dependency management
-  services.renovate.enable = true;
-
-  ## development
-  programs = {
-    direnv.enable = true;
-    # This should default by whether there is a .git file/dir (and whether it’s
-    # a file (worktree) or dir determines other things – like where hooks
-    # are installed.
-    git.enable = true;
-  };
-
-  ## formatting
-  editorconfig.enable = true;
-  programs = {
-    treefmt.enable = true;
-    vale.enable = true;
-  };
-
-  ## CI
-  services.garnix.enable = true;
-
   ## publishing
-  services = {
-    flakehub.enable = true;
-    github.enable = true;
-  };
+  services.github.settings.repository.topics = [];
 }

--- a/templates/default/.config/project/default.nix
+++ b/templates/default/.config/project/default.nix
@@ -1,38 +1,11 @@
-{
-  config,
-  lib,
-  ...
-}: {
+### All available options for this file are listed in
+### https://sellout.github.io/project-manager/options.xhtml
+{...}: {
   project = {
     name = "{{project.name}}";
     summary = "{{project.summary}}";
   };
 
-  ## dependency management
-  services.renovate.enable = true;
-
-  ## development
-  programs = {
-    direnv.enable = true;
-    # This should default by whether there is a .git file/dir (and whether it’s
-    # a file (worktree) or dir determines other things – like where hooks
-    # are installed.
-    git.enable = true;
-  };
-
-  ## formatting
-  editorconfig.enable = true;
-  programs = {
-    treefmt.enable = true;
-    vale.enable = true;
-  };
-
-  ## CI
-  services.garnix.enable = true;
-
   ## publishing
-  services = {
-    flakehub.enable = true;
-    github.enable = true;
-  };
+  services.github.settings.repository.topics = [];
 }

--- a/templates/dhall/.config/project/default.nix
+++ b/templates/dhall/.config/project/default.nix
@@ -1,47 +1,14 @@
-{
-  config,
-  flaky,
-  lib,
-  pkgs,
-  supportedSystems,
-  ...
-}: {
+### All available options for this file are listed in
+### https://sellout.github.io/project-manager/options.xhtml
+{...}: {
   project = {
     name = "{{project.name}}";
     summary = "{{project.summary}}";
-
-    devPackages = [
-      pkgs.dhall
-      pkgs.dhall-docs
-      pkgs.dhall-lsp-server
-    ];
-  };
-
-  ## dependency managerment
-  services.renovate.enable = true;
-
-  ## development
-  programs = {
-    direnv.enable = true;
-    # This should default by whether there is a .git file/dir (and whether it’s
-    # a file (worktree) or dir determines other things – like where hooks
-    # are installed.
-    git.enable = true;
   };
 
   ## formatting
-  editorconfig.enable = true;
-  programs = {
-    treefmt.enable = true;
-    vale.enable = true;
-  };
   project.file.".dir-locals.el".source = ../emacs/.dir-locals.el;
 
-  ## CI
-  services.garnix.enable = true;
-
   ## publishing
-  services.flakehub.enable = true;
-  services.github.enable = true;
-  services.github.settings.repository.topics = ["library"];
+  services.github.settings.repository.topics = [];
 }

--- a/templates/emacs-lisp/.config/project/default.nix
+++ b/templates/emacs-lisp/.config/project/default.nix
@@ -1,35 +1,11 @@
-{
-  config,
-  flaky,
-  lib,
-  supportedSystems,
-  ...
-}: {
+### All available options for this file are listed in
+### https://sellout.github.io/project-manager/options.xhtml
+{...}: {
   project = {
     name = "{{project.name}}";
     summary = "{{project.summary}}";
   };
 
-  ## dependency management
-  services.renovate.enable = true;
-
-  ## development
-  programs = {
-    direnv.enable = true;
-    git.enable = true;
-  };
-
-  ## formatting
-  editorconfig.enable = true;
-  programs = {
-    treefmt.enable = true;
-    vale.enable = true;
-  };
-
-  ## CI
-  services.garnix.enable = true;
-
   ## publishing
-  services.flakehub.enable = true;
-  services.github.enable = true;
+  services.github.settings.repository.topics = [];
 }

--- a/templates/haskell/.config/project/default.nix
+++ b/templates/haskell/.config/project/default.nix
@@ -1,10 +1,9 @@
+### All available options for this file are listed in
+### https://sellout.github.io/project-manager/options.xhtml
 {
   config,
-  flaky,
   lib,
-  pkgs,
   self,
-  supportedSystems,
   ...
 }: {
   project = {
@@ -25,28 +24,7 @@
 
   imports = [./hlint.nix];
 
-  ## dependency management
-  services.renovate.enable = true;
-
-  ## development
-  programs = {
-    direnv.enable = true;
-    # This should default by whether there is a .git file/dir (and whether it’s
-    # a file (worktree) or dir determines other things – like where hooks
-    # are installed.
-    git.enable = true;
-  };
-
-  ## formatting
-  editorconfig.enable = true;
-
-  programs = {
-    treefmt.enable = true;
-    vale.enable = true;
-  };
-
   ## CI
-  services.garnix.enable = true;
   ## FIXME: Shouldn’t need `mkForce` here (or to duplicate the base contexts).
   ##        Need to improve module merging.
   services.github.settings.branches.main.protection.required_status_checks.contexts =
@@ -71,6 +49,5 @@
   };
 
   ## publishing
-  services.github.enable = true;
   services.github.settings.repository.topics = [];
 }

--- a/templates/nix/.config/project/default.nix
+++ b/templates/nix/.config/project/default.nix
@@ -1,38 +1,11 @@
-{
-  config,
-  lib,
-  ...
-}: {
+### All available options for this file are listed in
+### https://sellout.github.io/project-manager/options.xhtml
+{...}: {
   project = {
     name = "{{project.name}}";
     summary = "{{project.summary}}";
   };
 
-  ## dependency management
-  services.renovate.enable = true;
-
-  ## development
-  programs = {
-    direnv.enable = true;
-    # This should default by whether there is a .git file/dir (and whether it’s
-    # a file (worktree) or dir determines other things – like where hooks
-    # are installed.
-    git.enable = true;
-  };
-
-  ## formatting
-  editorconfig.enable = true;
-  programs = {
-    treefmt.enable = true;
-    vale.enable = true;
-  };
-
-  ## CI
-  services.garnix.enable = true;
-
   ## publishing
-  services = {
-    flakehub.enable = true;
-    github.enable = true;
-  };
+  services.github.settings.repository.topics = [];
 }


### PR DESCRIPTION
Minimize the templates as much as possible, and pull the settings from Flaky. The less that’s in the template, the less work `sync-template` entails.

This also adds a comment to the top of each project configuration, linking to the options docs.